### PR TITLE
Add TransactionController and tests

### DIFF
--- a/src/Controller/TransactionController.php
+++ b/src/Controller/TransactionController.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class TransactionController
+{
+    #[Route('/transactions', name: 'transaction_create', methods: ['POST'])]
+    public function create(): JsonResponse
+    {
+        return new JsonResponse(['status' => 'created']);
+    }
+
+    #[Route('/transactions/{id}', name: 'transaction_update', methods: ['PUT'])]
+    public function update(int $id): JsonResponse
+    {
+        return new JsonResponse(['status' => 'updated', 'id' => $id]);
+    }
+
+    #[Route('/transactions/{id}', name: 'transaction_delete', methods: ['DELETE'])]
+    public function delete(int $id): JsonResponse
+    {
+        return new JsonResponse(['status' => 'deleted', 'id' => $id]);
+    }
+}

--- a/tests/Controller/TransactionControllerTest.php
+++ b/tests/Controller/TransactionControllerTest.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use PHPUnit\Framework\TestCase;
+use App\Controller\TransactionController;
+
+class TransactionControllerTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $controller = new TransactionController();
+        $response = $controller->create();
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString('{"status":"created"}', $response->getContent());
+    }
+
+    public function testUpdate(): void
+    {
+        $controller = new TransactionController();
+        $response = $controller->update(5);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString('{"status":"updated","id":5}', $response->getContent());
+    }
+
+    public function testDelete(): void
+    {
+        $controller = new TransactionController();
+        $response = $controller->delete(2);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString('{"status":"deleted","id":2}', $response->getContent());
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,3 +3,5 @@ declare(strict_types=1);
 
 require_once __DIR__.'/stubs/ManagerRegistry.php';
 require_once __DIR__.'/stubs/ServiceEntityRepository.php';
+require_once __DIR__.'/stubs/JsonResponse.php';
+require_once __DIR__.'/stubs/Route.php';

--- a/tests/stubs/JsonResponse.php
+++ b/tests/stubs/JsonResponse.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Symfony\Component\HttpFoundation;
+
+class JsonResponse
+{
+    private $data;
+    private int $status;
+
+    public function __construct($data = null, int $status = 200)
+    {
+        $this->data = $data;
+        $this->status = $status;
+    }
+
+    public function getContent(): string
+    {
+        return json_encode($this->data);
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->status;
+    }
+}

--- a/tests/stubs/Route.php
+++ b/tests/stubs/Route.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Symfony\Component\Routing\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Route
+{
+    public function __construct(
+        public string $path,
+        public string $name = '',
+        public array $methods = []
+    ) {
+    }
+}


### PR DESCRIPTION
## Summary
- add `TransactionController` with create/update/delete endpoints
- provide stubbed `JsonResponse` and `Route` so tests run without external deps
- update bootstrap to include new stubs
- add tests for the controller endpoints

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d355abc8c8321932c47c73d2e83bb